### PR TITLE
Add debug mode

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -21,8 +21,11 @@ server.register(require('vision'), function (err) {
 server.register({
   register: require('../'),
   options: {
-    'something': 'Something',
-    'nested.something': 'Nested'
+    enableDebug: true,
+    context: {
+      'something': 'Something',
+      'nested.something': 'Nested'
+    }
   }
 }, function (err) {
   if (err) {

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 var _ = require('lodash');
 
 exports.register = function(server, options, next) {
-
   options = options || {};
 
   var addContext = function(request, key, data) {
@@ -29,7 +28,20 @@ exports.register = function(server, options, next) {
   server.expose('addContext', addContext);
 
   server.ext('onPreResponse', function(request, reply) {
-    addContext(request, options);
+    addContext(request, options.context);
+
+    if (options.enableDebug && typeof request.query.context === 'string') {
+      var selected = _.get(request.response.source.context, request.query.context);
+      var context = request.response.source.context;
+
+      if (selected !== undefined) {
+        var out = {};
+        out[request.query.context] = selected;
+        context = out;
+      }
+
+      return reply(context);
+    }
 
     reply.continue();
   });


### PR DESCRIPTION
Fixes #6

If you have debug mode enabled and pass in `?context` with nothing or a non matching item the whole context comes back, otherwise you can pass a dot notation string and get that particular value.
